### PR TITLE
NFSMW - Allow to create custom ranked games

### DIFF
--- a/src/main/java/com/ea/services/core/GameService.java
+++ b/src/main/java/com/ea/services/core/GameService.java
@@ -36,6 +36,7 @@ import static com.ea.utils.SocketUtils.getValueFromSocket;
 @Service
 public class GameService {
 
+    public static final String NFS_MW_CONVERT_TO_RANKED_PASSWORD = "ranked";
     private final GameRepository gameRepository;
     private final GameConnectionRepository gameConnectionRepository;
     private final PersonaConnectionRepository personaConnectionRepository;
@@ -639,6 +640,14 @@ public class GameService {
 
         List<String> relatedVers = gameServerService.getRelatedVers(vers);
         boolean duplicateName = gameRepository.existsByNameAndVersInAndEndTimeIsNull(gameEntity.getName(), relatedVers);
+
+        // Custom logic for NFS Most Wanted clients allowing to create custom ranked games based on unranked game parameters
+        // To do so, a specific password ("ranked") must be provided, then we set the sysflags to 262144 (ranked) and remove the password
+        if (PSP_NFS_06.equals(vers) && gameEntity.getSysflags().equals("0")
+                && gameEntity.getPass() != null && gameEntity.getPass().equals(NFS_MW_CONVERT_TO_RANKED_PASSWORD)) {
+            gameEntity.setSysflags("262144");
+            gameEntity.setPass(null);
+        }
 
         if (duplicateName) {
             socketData.setIdMessage("gcredupl");


### PR DESCRIPTION
On NFS MW the default parameters for ranked games are:
- CPU racers - ON
- cops - ON
- traffic - MEDIUM

... which isn't a fun experience  

The idea behind this feature is to allow players to convert unranked games (where parameters customisation is allowed) into ranked games.  
**To enable this feature, the host must set the password to `ranked` on game creation.** The unranked game is then switched to ranked and the password is removed.
