### PR TITLE
Support Burnout Domination

### DIFF
--- a/src/main/java/com/ea/ServerApp.java
+++ b/src/main/java/com/ea/ServerApp.java
@@ -84,10 +84,16 @@ public class ServerApp implements CommandLineRunner {
 
     private void startGameServer(GameServerConfig.GameServer gameServer) throws Exception {
         for (GameServerConfig.RegionConfig region : gameServer.getRegions()) {
+            // Build VERS display string (include dedicated VERS if present)
+            String versDisplay = gameServer.getVers();
+            if (gameServer.getDedicated() != null && gameServer.getDedicated().getVers() != null) {
+                versDisplay += ", " + gameServer.getDedicated().getVers();
+            }
+
             // TCP server
             ServerSocket tcpServerSocket = serverConfig.createTcpServerSocket(region.getPort());
             startServerThread(tcpServerSocket, this::createTcpSocketThread, gameServer.isAries());
-            log.info("Started TCP server for {} {} on port {}", gameServer.getVers(), region.getName(), region.getPort());
+            log.info("Started TCP server for {} {} on port {}", versDisplay, region.getName(), region.getPort());
 
             // SSL server
             if (gameServer.getSsl() != null && gameServer.getSsl().isEnabled() && gameServer.getSsl().getDomain() != null) {
@@ -97,7 +103,7 @@ public class ServerApp implements CommandLineRunner {
 
                 SSLServerSocket sslServerSocket = serverConfig.createSslServerSocket(sslPort, subject, issuer, gameServer.getVers());
                 startServerThread(sslServerSocket, this::createSslSocketThread, true);
-                log.info("Started SSL server for {} {} on port {}", gameServer.getVers(), region.getName(), sslPort);
+                log.info("Started SSL server for {} {} on port {}", versDisplay, region.getName(), sslPort);
             }
         }
     }

--- a/src/main/java/com/ea/config/GameServerConfig.java
+++ b/src/main/java/com/ea/config/GameServerConfig.java
@@ -24,11 +24,16 @@ public class GameServerConfig {
         private List<RegionConfig> regions;
     }
 
+    /**
+     * Dedicated server configuration.
+     * Used for games requiring multiple VERS identifiers.
+     * If port is null, the dedicated VERS shares the main server's region ports.
+     */
     @Data
     public static class DedicatedConfig {
         private String vers;
         private String slus;
-        private int port;
+        private Integer port; // Nullable: if null, shares main server's ports
     }
 
     @Data

--- a/src/main/java/com/ea/services/server/GameServerService.java
+++ b/src/main/java/com/ea/services/server/GameServerService.java
@@ -78,7 +78,18 @@ public class GameServerService {
                         server.getDedicated().getVers().equals(vers) &&
                         server.getDedicated().getSlus() != null &&
                         server.getDedicated().getSlus().equals(slus))
-                .map(server -> server.getDedicated().getPort())
+                .map(server -> {
+                    // If dedicated server has explicit port, use it
+                    if (server.getDedicated().getPort() != null) {
+                        return server.getDedicated().getPort();
+                    }
+                    // Otherwise, fall back to main server's first region port (shared port for multi-VERS games)
+                    // Note: dedicated SLUS is different from region SLUS, so we can't filter by SLUS here
+                    return server.getRegions().stream()
+                            .findFirst()
+                            .map(GameServerConfig.RegionConfig::getPort)
+                            .orElse(-1);
+                })
                 .findFirst()
                 .orElse(-1));
     }
@@ -135,7 +146,8 @@ public class GameServerService {
     public Optional<GameServerConfig.GameServer> getServerByVers(String vers) {
         return gameServerConfig.getServers().stream()
                 .filter(GameServerConfig.GameServer::isEnabled)
-                .filter(server -> server.getVers().equals(vers))
+                .filter(server -> server.getVers().equals(vers) ||
+                        (server.getDedicated() != null && server.getDedicated().getVers() != null && server.getDedicated().getVers().equals(vers)))
                 .findFirst();
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,21 @@ game:
       regions:
         - name: 'GLOBAL'
           port: 5000 # Arbitrary buddy port, set anything you want
+    - vers: 'PSP/BURNOUT07' # Burnout Dominator (login & register)
+      sdk: '4.9.0.0'
+      # Not a real dedicated server - this is a technique to support multiple VERS for the same game
+      dedicated:
+        vers: 'FLM/A1' # Burnout Dominator (view leaderboards, upload stats, download tracks)
+        slus: 'SLUS-FLAME'
+        # No port specified - shares the main server's region ports
+        # sdk is 4.8.1.0
+      ssl:
+        domain: 'pspburnout07.ea.com'
+      regions:
+        - name: 'GLOBAL'
+          port: 11890
+          slus:
+            - 'ULES00703'
     - vers: 'PSP/UEFA07' # UEFA Champions League 2006-2007
       sdk: '4.3.2.0'
       ssl:


### PR DESCRIPTION
Closes #16 

- Refactor architecture to support Burnout Dominator as this game uses 2 VERS which is uncommon
- Implement login & register (already handled by default, but there seems to be an infinite loop of login - it can be stopped)
- (TODO) Implement Burnout Dominator services: view leaderboards, upload stats, download tracks